### PR TITLE
Don't allow clickthrough for options without options (credits, controls)

### DIFF
--- a/Assets/OptionScript.cs
+++ b/Assets/OptionScript.cs
@@ -37,7 +37,6 @@ public class OptionScript : MonoBehaviour
     IEnumerator SlideTo(float newValue) {
 		isSliding = true;
 		slider.value = newValue;
-		Debug.Log(slider.value);
         yield return new WaitForSeconds(slideDurationSeconds);
 		isSliding = false;
     }

--- a/Assets/Scenes/optionsScene.unity
+++ b/Assets/Scenes/optionsScene.unity
@@ -225,7 +225,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0000038146973, y: 375.10004}
+  m_AnchoredPosition: {x: 0, y: 375.10004}
   m_SizeDelta: {x: 0, y: -750.2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &82986380
@@ -270,6 +270,44 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 82986378}
   m_CullTransparentMesh: 0
+--- !u!1 &88691589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 88691590}
+  m_Layer: 5
+  m_Name: OptionEditButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &88691590
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88691589}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9998999, y: 0.9998999, z: 0.9998999}
+  m_Children:
+  - {fileID: 377405401}
+  - {fileID: 573909194}
+  - {fileID: 1527895636}
+  m_Father: {fileID: 312476434}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 135, y: 367.5}
+  m_SizeDelta: {x: 156.6, y: 76.9}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &127938612
 GameObject:
   m_ObjectHideFlags: 0
@@ -574,7 +612,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 2.0000124, y: -189.34991}
+  m_AnchoredPosition: {x: 2, y: -189.34991}
   m_SizeDelta: {x: 0, y: 9.099976}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &242646819
@@ -653,7 +691,7 @@ RectTransform:
   - {fileID: 2040541045}
   - {fileID: 1621138668}
   m_Father: {fileID: 312476434}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -781,7 +819,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 8.999991, y: -26.199995}
+  m_AnchoredPosition: {x: 9, y: -26.199982}
   m_SizeDelta: {x: 0, y: 9.099976}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &305128872
@@ -918,6 +956,7 @@ RectTransform:
   m_Children:
   - {fileID: 194896619}
   - {fileID: 724076628}
+  - {fileID: 88691590}
   - {fileID: 246363909}
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1065,6 +1104,85 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &377405400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 377405401}
+  - component: {fileID: 377405403}
+  - component: {fileID: 377405402}
+  m_Layer: 5
+  m_Name: Breadcrumb Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &377405401
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 377405400}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 88691590}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 30, y: 11.095001}
+  m_SizeDelta: {x: -55.99, y: -22.19}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &377405402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 377405400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 24299d427e090474eba7f072182ac4b1, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: EDIT
+--- !u!222 &377405403
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 377405400}
+  m_CullTransparentMesh: 0
 --- !u!1 &392899607
 GameObject:
   m_ObjectHideFlags: 0
@@ -1530,6 +1648,90 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &573909193
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 573909194}
+  - component: {fileID: 573909195}
+  m_Layer: 5
+  m_Name: Button Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &573909194
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 573909193}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 25, y: 25, z: 1}
+  m_Children: []
+  m_Father: {fileID: 88691590}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -67.6, y: 19.2}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!212 &573909195
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 573909193}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 5f0b47a3111b5493fbbc8d36a0b87a60, type: 3}
+  m_Color: {r: 0.14150944, g: 0.5660378, b: 0.26304105, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &600351921
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1784,7 +1986,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 6.9999876, y: -279.65002}
+  m_AnchoredPosition: {x: 7, y: -279.65002}
   m_SizeDelta: {x: 0, y: -750.2001}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &790893723
@@ -2908,7 +3110,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 2.0000124, y: 134.45012}
+  m_AnchoredPosition: {x: 2, y: 134.45013}
   m_SizeDelta: {x: 0, y: 9.099976}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1304073607
@@ -3341,6 +3543,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1523963280}
+  m_CullTransparentMesh: 0
+--- !u!1 &1527895635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1527895636}
+  - component: {fileID: 1527895638}
+  - component: {fileID: 1527895637}
+  m_Layer: 5
+  m_Name: Button Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1527895636
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527895635}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9998999, y: 0.9998999, z: 0.9998999}
+  m_Children: []
+  m_Father: {fileID: 88691590}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.000015258789}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1527895637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527895635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 24299d427e090474eba7f072182ac4b1, type: 3}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: A
+--- !u!222 &1527895638
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527895635}
   m_CullTransparentMesh: 0
 --- !u!1 &1544059678
 GameObject:
@@ -3777,7 +4058,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Shader: {fileID: 4800000, guid: 6b426a8c366d0584dadb551db862ddeb, type: 3}
   AutomaticPhase: 1
-  Phase: 424.36795
+  Phase: 429.4799
   ConvertToGrayscale: 0
   NoiseIntensity: 0.4
   ScanlinesIntensity: 0.5
@@ -5507,6 +5788,7 @@ MonoBehaviour:
   options: {fileID: 246363908}
   breadcrumb: {fileID: 194896618}
   optionBreadcrumb: {fileID: 724076627}
+  optionEditButton: {fileID: 88691589}
   leftBackground: {fileID: 600351923}
   rightBackground: {fileID: 1234947124}
 --- !u!4 &2126456561

--- a/Assets/Scripts/OptionsManagerScript.cs
+++ b/Assets/Scripts/OptionsManagerScript.cs
@@ -1,17 +1,20 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using UnityEngine.EventSystems;
 
-public class OptionsManagerScript : MonoBehaviour {
+public class OptionsManagerScript : MonoBehaviour
+{
 
 	public GameObject curtain;
 	public CarouselScript carousel;
 	public GameObject options;
 	public GameObject breadcrumb;
 	public GameObject optionBreadcrumb;
+	public GameObject optionEditButton;
 	public GameObject leftBackground;
 	public GameObject rightBackground;
 
@@ -23,32 +26,46 @@ public class OptionsManagerScript : MonoBehaviour {
 
 	private EventSystem es;
 
-	void Start () {
+	static private int[] validIndexes = { 0, 1, 2 };
+
+	void Start()
+	{
 		curtain.SetActive(true);
 		curtain.GetComponent<NewFadeScript>().Fade(0f);
 
 		es = EventSystem.current;
-		if (es && es.currentSelectedGameObject) {
+		if (es && es.currentSelectedGameObject)
+		{
 			selectedIndex = es.currentSelectedGameObject.transform.GetSiblingIndex();
 		}
 
 		// determine which controller is 'in control'.
 		whichPlayerIsControlling = DataManagerScript.gamepadControllingMenus;
-		joyButts = new JoystickButtons (whichPlayerIsControlling);
+		joyButts = new JoystickButtons(whichPlayerIsControlling);
 	}
 
 	// Update is called once per frame
-	void Update () {
+	void Update()
+	{
+		// Check for selection to enable selectable option
+		bool inputSelecting = Input.GetButtonDown(joyButts.jump) || Input.GetButtonDown(joyButts.jump);
+		bool optionIsSelectable = OptionsManagerScript.CheckSelectableOptionIndex(selectedIndex);
+		optionEditButton.SetActive(optionIsSelectable && !optionIsOpen);
+
 		// Show options based on carousel slide selected
-		if (es.currentSelectedGameObject) {
+		if (es.currentSelectedGameObject)
+		{
 			int selectedSlideIndex = es.currentSelectedGameObject.transform.GetSiblingIndex();
-			if (selectedIndex != selectedSlideIndex) {
+			if (selectedIndex != selectedSlideIndex)
+			{
 				ShowOption(selectedSlideIndex);
+
 			}
 		}
 
 		// Check for cancel button
-		if (Input.GetButtonDown(joyButts.grav)) {
+		if (Input.GetButtonDown(joyButts.grav))
+		{
 
 			// Show/hide UI
 			optionBreadcrumb.SetActive(false);
@@ -56,7 +73,8 @@ public class OptionsManagerScript : MonoBehaviour {
 			leftBackground.SetActive(false);
 			rightBackground.SetActive(true);
 
-			if (optionIsOpen) {
+			if (optionIsOpen)
+			{
 				// Disable currently selected option
 				Transform selectedOption = options.transform.GetChild(selectedIndex);
 				selectedOption.GetComponent<OptionScript>().disable();
@@ -64,14 +82,15 @@ public class OptionsManagerScript : MonoBehaviour {
 				// Go back to carousel controls
 				optionIsOpen = false;
 			}
-			else {
+			else
+			{
 				// Go to previous scene
-				SceneManager.LoadSceneAsync ("titleScene");
+				SceneManager.LoadSceneAsync("titleScene");
 			}
 		}
 
-		// Check for selection to enable option
-		if (Input.GetButtonDown(joyButts.jump) && !optionIsOpen) {
+		if (inputSelecting && !optionIsOpen && optionIsSelectable)
+		{
 
 			// Show/hide UI
 			optionBreadcrumb.SetActive(true);
@@ -86,16 +105,27 @@ public class OptionsManagerScript : MonoBehaviour {
 
 		// Disable carousel when we have an option open
 		es.enabled = !optionIsOpen;
-		if (es.enabled) {
+		if (es.enabled)
+		{
 			// Reset selected item on re-enable
 			es.SetSelectedGameObject(carousel.slides[selectedIndex].gameObject);
 		}
 	}
 
-	void ShowOption(int newIndex) {
+	// TODO: move this to a property on the slides
+	static bool CheckSelectableOptionIndex(int index)
+	{
+		int pos = Array.IndexOf(OptionsManagerScript.validIndexes, index);
+		return pos > -1;
+	}
+
+	void ShowOption(int newIndex)
+	{
 		// Hide all other options
-		foreach (Transform child in options.transform) {
-			if (child.gameObject.activeSelf) {
+		foreach (Transform child in options.transform)
+		{
+			if (child.gameObject.activeSelf)
+			{
 				StartCoroutine(FadeOption(child, false));
 			}
 		}
@@ -108,14 +138,14 @@ public class OptionsManagerScript : MonoBehaviour {
 		selectedIndex = newIndex;
 	}
 
-	void SelectShownOption() {
+	void SelectShownOption()
+	{
 		Transform selectedOption = options.transform.GetChild(selectedIndex);
 		selectedOption.GetComponent<OptionScript>().enable();
 	}
 
-	// TODO: WHY AINT THIS WORK
-
-	IEnumerator FadeOption(Transform option, bool isAppearing) {
+	IEnumerator FadeOption(Transform option, bool isAppearing)
+	{
 		CanvasGroup optionCanvasGroup = option.GetComponent<CanvasGroup>();
 		float approxNoOfFrames = 20;
 

--- a/Assets/Scripts/OptionsManagerScript.cs
+++ b/Assets/Scripts/OptionsManagerScript.cs
@@ -110,7 +110,6 @@ public class OptionsManagerScript : MonoBehaviour {
 
 	void SelectShownOption() {
 		Transform selectedOption = options.transform.GetChild(selectedIndex);
-		Debug.Log(selectedOption);
 		selectedOption.GetComponent<OptionScript>().enable();
 	}
 


### PR DESCRIPTION
This was supposed to be in the last PR, but I forgot to manage the fact that I was working in a forked repo. I think I'm just going to remove this fork and work in feature branches in the main repo, from now on. 